### PR TITLE
Publication endpoint filtering

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -21,6 +21,7 @@ djangorestframework-camel-case = "*"
 django-oauth-toolkit = "*"
 django-cors-middleware = "*"
 pyuploadcare = "*"
+django-filter = "*"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9ce595c91809643aeeb2e174c370a75c58d4e3cf362cfdfd07cdeb947add58d7"
+            "sha256": "b1c8d283ce9f64477b5a3c72eaddfac3817dbfc60f06192f0182ea007af427e5"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -75,6 +75,13 @@
                 "sha256:25d7e3132e9533be83f62767fca9dc92d66ac9aee414559144ccbce2c2913d70"
             ],
             "version": "==1.3.1"
+        },
+        "django-filter": {
+            "hashes": [
+                "sha256:3dafb7d2810790498895c22a1f31b2375795910680ac9c1432821cbedb1e176d",
+                "sha256:a3014de317bef0cd43075a0f08dfa1d319a7ccc5733c3901fb860da70b0dda68"
+            ],
+            "version": "==2.1.0"
         },
         "django-oauth-toolkit": {
             "hashes": [

--- a/postpost/api/filters.py
+++ b/postpost/api/filters.py
@@ -1,0 +1,27 @@
+from django_filters import rest_framework as filters
+
+from api import models
+
+
+class PublicationFilterSet(filters.FilterSet):
+    """
+    Uses for filtering in publication-list endpoint by query-string.
+    """
+
+    # scheduled=false is equivalent to scheduled_at__isnull=True
+    scheduled = filters.BooleanFilter(
+        field_name='scheduled_at',
+        lookup_expr='isnull',
+        exclude=True,
+    )
+
+    # If you want change this filtering, first read comment
+    # for PlatformPost.PLATFORM_TYPES
+    platform_types = filters.MultipleChoiceFilter(
+        field_name='platform_posts__platform_type',
+        choices=models.PlatformPost.PLATFORM_TYPES,
+    )
+
+    class Meta(object):
+        model = models.Publication
+        fields = ['scheduled', 'platform_types']

--- a/postpost/api/models/platform_settings.py
+++ b/postpost/api/models/platform_settings.py
@@ -12,6 +12,17 @@ class PlatformPost(models.Model):
     TELEGRAM_CHANNEL_TYPE: Final = 'telegram_channel'
     TELEGRAM_SUPERGROUP_TYPE: Final = 'telegram_supergroup'
     VK_GROUP_TYPE: Final = 'vk_group'
+
+    # from boger:
+    # I think that in the future we will use two variables for describing
+    # platforms: platform (vk_group, twitter_account, telegram_channel) and
+    # integration (api, ifttt, buffer). Platform variable will be responsible
+    # for platform only, because if you want filter `publication to twitter`
+    # you doesn't care about ifttt or buffer, you want see all twitter
+    # publication.
+    #
+    # Maybe integration type should ruled by PlatformSetting or only on
+    # frontend-side, I'm not sure.
     PLATFORM_TYPES: Final = [
         (TELEGRAM_CHANNEL_TYPE, 'Telegram Channel'),
         (TELEGRAM_SUPERGROUP_TYPE, 'Telegram Supergroup (chat)'),

--- a/postpost/api/serializers.py
+++ b/postpost/api/serializers.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from typing import Dict, Sequence
+from typing import Dict, Sequence, Type
 
 from django.contrib.auth import models as contrib_models
 from django.utils import timezone
@@ -52,7 +52,7 @@ class PlatformSettingsRelatedField(serializers.ModelSerializer):
     Special hack field which on the fly change serializer class depending on platform_type.
     """
 
-    serializers_by_type: Dict[str, serializers.ModelSerializer] = {
+    serializers_by_type: Dict[str, Type[serializers.ModelSerializer]] = {
         models.PlatformPost.VK_GROUP_TYPE: VKGroupSettingsSerializer,
         models.PlatformPost.TELEGRAM_CHANNEL_TYPE: TelegramChannelSettingsSerializer,
         models.PlatformPost.TELEGRAM_SUPERGROUP_TYPE: TelegramChannelSettingsSerializer,  # FIXME

--- a/postpost/api/views.py
+++ b/postpost/api/views.py
@@ -1,7 +1,8 @@
+from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.generics import CreateAPIView, ListCreateAPIView, RetrieveUpdateDestroyAPIView
 from rest_framework.permissions import AllowAny, IsAuthenticated
 
-from api import models, serializers
+from api import filters, models, serializers
 
 
 class PublicationList(ListCreateAPIView):
@@ -12,6 +13,8 @@ class PublicationList(ListCreateAPIView):
     permission_classes = [IsAuthenticated]
     queryset = models.Publication.objects.all()
     serializer_class = serializers.PublicationSerializer
+    filter_backends = (DjangoFilterBackend,)
+    filterset_class = filters.PublicationFilterSet
 
 
 class Publication(RetrieveUpdateDestroyAPIView):

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ per-file-ignores =
     serializers.py: D106,
     serializers/*.py: D106,
     filters.py: D106,
-    filtres/*.py: D106,
+    filters/*.py: D106,
     # disable for `id` class attribute in model definition "is a python builtin, consider renaming the class attribute"
     models/*.py: A003,
     models.py: A003,

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,8 @@ per-file-ignores =
     models.py: D106,
     serializers.py: D106,
     serializers/*.py: D106,
+    filters.py: D106,
+    filtres/*.py: D106,
     # disable for `id` class attribute in model definition "is a python builtin, consider renaming the class attribute"
     models/*.py: A003,
     models.py: A003,


### PR DESCRIPTION
Resolves #34 

Implements query filtering like
`/publications?scheduled=true`
`/publications?scheduled=false&platform_types=vk_group&platform_types=telegram_channel`
`/publications?scheduled=1&platform_types[]=vk_group&platform_types[]=telegram_supergroup`