### PR TITLE
Move oauth, swagger and redoc to /api endpoint.

### DIFF
--- a/postpost/main/settings.py
+++ b/postpost/main/settings.py
@@ -155,12 +155,11 @@ SWAGGER_SETTINGS = {
     'SECURITY_DEFINITIONS': {
         'API': {
             'type': 'oauth2',
-            'authorizationUrl': '/oauth/authorize',
-            'tokenUrl': '/oauth/token/',
+            'authorizationUrl': '/api/oauth/authorize',
+            'tokenUrl': '/api/oauth/token/',
             'flow': 'password',
         },
     },
-    'OAUTH2_REDIRECT_URL': '/swagger',
 }
 
 CORS_ORIGIN_ALLOW_ALL = True

--- a/postpost/main/urls.py
+++ b/postpost/main/urls.py
@@ -17,9 +17,9 @@ schema_view = get_schema_view(
 
 
 urlpatterns = [
-    path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
-    path('redoc/', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
+    path('api/swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
+    path('api/redoc/', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
+    path('api/oauth/', include('oauth2_provider.urls', namespace='oauth2_provider')),
     path('api/', include('api.urls')),
     path('admin/', admin.site.urls),
-    path('oauth/', include('oauth2_provider.urls', namespace='oauth2_provider')),
 ]


### PR DESCRIPTION
Because we route to /api via nginx